### PR TITLE
Include/require/echo statements

### DIFF
--- a/PHP-HTML.mode/Contents/Resources/CodaCompletion.plist
+++ b/PHP-HTML.mode/Contents/Resources/CodaCompletion.plist
@@ -46,7 +46,7 @@
 	</dict>
 	<key>Completions</key>
 	<array>
-				<dict>
+		<dict>
 			<key>ID</key>
 			<string>abs</string>
 			<key>MoveCursor</key>

--- a/PHP-HTML.mode/Contents/Resources/CodaCompletion.plist
+++ b/PHP-HTML.mode/Contents/Resources/CodaCompletion.plist
@@ -2880,9 +2880,9 @@
 			<key>ID</key>
 			<string>echo</string>
 			<key>MoveCursor</key>
-			<string>1</string>
+			<string>2</string>
 			<key>PostString</key>
-			<string>()</string>
+			<string> '';</string>
 			<key>String</key>
 			<string>echo</string>
 		</dict>

--- a/PHP-HTML.mode/Contents/Resources/CodaCompletion.plist
+++ b/PHP-HTML.mode/Contents/Resources/CodaCompletion.plist
@@ -8240,9 +8240,9 @@
 			<key>ID</key>
 			<string>include</string>
 			<key>MoveCursor</key>
-			<string>1</string>
+			<string>2</string>
 			<key>PostString</key>
-			<string>()</string>
+			<string> '';</string>
 			<key>String</key>
 			<string>include</string>
 		</dict>
@@ -8250,9 +8250,9 @@
 			<key>ID</key>
 			<string>include_once</string>
 			<key>MoveCursor</key>
-			<string>1</string>
+			<string>2</string>
 			<key>PostString</key>
-			<string>()</string>
+			<string> '';</string>
 			<key>String</key>
 			<string>include_once</string>
 		</dict>
@@ -13900,9 +13900,9 @@
 			<key>ID</key>
 			<string>require</string>
 			<key>MoveCursor</key>
-			<string>1</string>
+			<string>2</string>
 			<key>PostString</key>
-			<string>()</string>
+			<string> '';</string>
 			<key>String</key>
 			<string>require</string>
 		</dict>
@@ -13910,9 +13910,9 @@
 			<key>ID</key>
 			<string>require_once</string>
 			<key>MoveCursor</key>
-			<string>1</string>
+			<string>2</string>
 			<key>PostString</key>
-			<string>()</string>
+			<string> '';</string>
 			<key>String</key>
 			<string>require_once</string>
 		</dict>


### PR DESCRIPTION
Thanks for your work in getting these into Coda 2 format. I've made a couple minor changes that I had in my own Coda 1 modes that you may be interested in.

Specifically I've changed echo, include, include_once, require, require_once to use their keyword forms rather than function style forms. This suits my own style more than the default, but also the PHP documentation embraces these forms over the older style.
